### PR TITLE
Enemy scripts, slime animations

### DIFF
--- a/TimeMachine/Assets/Pixel Adventure 2/Assets/Enemies/Slime/Hit.anim
+++ b/TimeMachine/Assets/Pixel Adventure 2/Assets/Enemies/Slime/Hit.anim
@@ -1,0 +1,53 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Hit
+  serializedVersion: 7
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings: []
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 1
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/TimeMachine/Assets/Pixel Adventure 2/Assets/Enemies/Slime/Hit.anim.meta
+++ b/TimeMachine/Assets/Pixel Adventure 2/Assets/Enemies/Slime/Hit.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f19efa272afc8c0fba6aff0bffc8059d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TimeMachine/Assets/Pixel Adventure 2/Assets/Enemies/Slime/Idle-Run.anim
+++ b/TimeMachine/Assets/Pixel Adventure 2/Assets/Enemies/Slime/Idle-Run.anim
@@ -1,0 +1,99 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Idle-Run
+  serializedVersion: 7
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves:
+  - serializedVersion: 2
+    curve:
+    - time: 0
+      value: {fileID: 4320010084133899996, guid: 52d40d1d463a123498d838dd108b712a, type: 3}
+    - time: 0.05
+      value: {fileID: -31681914721083726, guid: 52d40d1d463a123498d838dd108b712a, type: 3}
+    - time: 0.1
+      value: {fileID: 6085019124062519307, guid: 52d40d1d463a123498d838dd108b712a, type: 3}
+    - time: 0.13333334
+      value: {fileID: 5044515257469741075, guid: 52d40d1d463a123498d838dd108b712a, type: 3}
+    - time: 0.18333334
+      value: {fileID: 7161937680985596148, guid: 52d40d1d463a123498d838dd108b712a, type: 3}
+    - time: 0.23333333
+      value: {fileID: -1676692623272893389, guid: 52d40d1d463a123498d838dd108b712a, type: 3}
+    - time: 0.28333333
+      value: {fileID: 7659680398461486745, guid: 52d40d1d463a123498d838dd108b712a, type: 3}
+    - time: 0.31666666
+      value: {fileID: -3555855070186029808, guid: 52d40d1d463a123498d838dd108b712a, type: 3}
+    - time: 0.36666667
+      value: {fileID: 6870164852964529440, guid: 52d40d1d463a123498d838dd108b712a, type: 3}
+    - time: 0.41666666
+      value: {fileID: -5462098846767402552, guid: 52d40d1d463a123498d838dd108b712a, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+    flags: 2
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    pptrCurveMapping:
+    - {fileID: 4320010084133899996, guid: 52d40d1d463a123498d838dd108b712a, type: 3}
+    - {fileID: -31681914721083726, guid: 52d40d1d463a123498d838dd108b712a, type: 3}
+    - {fileID: 6085019124062519307, guid: 52d40d1d463a123498d838dd108b712a, type: 3}
+    - {fileID: 5044515257469741075, guid: 52d40d1d463a123498d838dd108b712a, type: 3}
+    - {fileID: 7161937680985596148, guid: 52d40d1d463a123498d838dd108b712a, type: 3}
+    - {fileID: -1676692623272893389, guid: 52d40d1d463a123498d838dd108b712a, type: 3}
+    - {fileID: 7659680398461486745, guid: 52d40d1d463a123498d838dd108b712a, type: 3}
+    - {fileID: -3555855070186029808, guid: 52d40d1d463a123498d838dd108b712a, type: 3}
+    - {fileID: 6870164852964529440, guid: 52d40d1d463a123498d838dd108b712a, type: 3}
+    - {fileID: -5462098846767402552, guid: 52d40d1d463a123498d838dd108b712a, type: 3}
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 0.43333334
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/TimeMachine/Assets/Pixel Adventure 2/Assets/Enemies/Slime/Idle-Run.anim.meta
+++ b/TimeMachine/Assets/Pixel Adventure 2/Assets/Enemies/Slime/Idle-Run.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bd16ab4d13119b263b92e3f2f5f64527
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TimeMachine/Assets/Pixel Adventure 2/Assets/Enemies/Slime/Slime Sprite.controller
+++ b/TimeMachine/Assets/Pixel Adventure 2/Assets/Enemies/Slime/Slime Sprite.controller
@@ -1,0 +1,101 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1107 &-6125359238152756446
+AnimatorStateMachine:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Base Layer
+  m_ChildStates:
+  - serializedVersion: 1
+    m_State: {fileID: -3602082540048482023}
+    m_Position: {x: 310, y: 70, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -1984107197559003639}
+    m_Position: {x: 154.91003, y: 529.06586, z: 0}
+  m_ChildStateMachines: []
+  m_AnyStateTransitions: []
+  m_EntryTransitions: []
+  m_StateMachineTransitions: {}
+  m_StateMachineBehaviours: []
+  m_AnyStatePosition: {x: 50, y: 20, z: 0}
+  m_EntryPosition: {x: 50, y: 120, z: 0}
+  m_ExitPosition: {x: 800, y: 120, z: 0}
+  m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
+  m_DefaultState: {fileID: -3602082540048482023}
+--- !u!1102 &-3602082540048482023
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Idle-Run
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 5d9a88d2f5232a9708121d3ed0d6df50, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &-1984107197559003639
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Idle-Run 0
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 5d9a88d2f5232a9708121d3ed0d6df50, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!91 &9100000
+AnimatorController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Slime Sprite
+  serializedVersion: 5
+  m_AnimatorParameters: []
+  m_AnimatorLayers:
+  - serializedVersion: 5
+    m_Name: Base Layer
+    m_StateMachine: {fileID: -6125359238152756446}
+    m_Mask: {fileID: 0}
+    m_Motions: []
+    m_Behaviours: []
+    m_BlendingMode: 0
+    m_SyncedLayerIndex: -1
+    m_DefaultWeight: 0
+    m_IKPass: 0
+    m_SyncedLayerAffectsTiming: 0
+    m_Controller: {fileID: 9100000}

--- a/TimeMachine/Assets/Pixel Adventure 2/Assets/Enemies/Slime/Slime Sprite.controller.meta
+++ b/TimeMachine/Assets/Pixel Adventure 2/Assets/Enemies/Slime/Slime Sprite.controller.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 77c67e5736bcd7fde8614d10cffab20d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TimeMachine/Assets/Prefabs/Feet.prefab
+++ b/TimeMachine/Assets/Prefabs/Feet.prefab
@@ -1,0 +1,83 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3577935724178491867
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6007413538866340606}
+  - component: {fileID: 8764390540697651260}
+  - component: {fileID: 8402771634019729399}
+  m_Layer: 0
+  m_Name: Feet
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6007413538866340606
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3577935724178491867}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!70 &8764390540697651260
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3577935724178491867}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0.0041415715, y: -0.14540185}
+  m_Size: {x: 0.14382292, y: 0.025742766}
+  m_Direction: 1
+--- !u!114 &8402771634019729399
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3577935724178491867}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 55b60cbfd40f1e0cfb2d18629cd1e4c6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  playerMovement: {fileID: 0}

--- a/TimeMachine/Assets/Prefabs/Feet.prefab.meta
+++ b/TimeMachine/Assets/Prefabs/Feet.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 35b8bce522278dbeba0e69b77d2feb16
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TimeMachine/Assets/Prefabs/Patrol Point.prefab
+++ b/TimeMachine/Assets/Prefabs/Patrol Point.prefab
@@ -1,0 +1,33 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &85597763793783509
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 607596846395285866}
+  m_Layer: 0
+  m_Name: Patrol Point
+  m_TagString: Patrol Point
+  m_Icon: {fileID: -964228994112308473, guid: 0000000000000000d000000000000000, type: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &607596846395285866
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 85597763793783509}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -10.45, y: -1.61, z: -0.060083102}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/TimeMachine/Assets/Prefabs/Patrol Point.prefab.meta
+++ b/TimeMachine/Assets/Prefabs/Patrol Point.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0ac7d23658b5c4b4fbb711780c90fa11
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TimeMachine/Assets/Prefabs/Player.prefab
+++ b/TimeMachine/Assets/Prefabs/Player.prefab
@@ -40,6 +40,7 @@ Transform:
   - {fileID: 3749688521435561974}
   - {fileID: 3872590710753552111}
   - {fileID: 6468770203123137245}
+  - {fileID: 5149678124750449336}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &8234870398897454006
@@ -109,7 +110,7 @@ Rigidbody2D:
   m_Mass: 1.1
   m_LinearDrag: 0
   m_AngularDrag: 0.05
-  m_GravityScale: 1
+  m_GravityScale: 1.55
   m_Material: {fileID: 0}
   m_IncludeLayers:
     serializedVersion: 2
@@ -153,8 +154,8 @@ CapsuleCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0.002516669, y: -0.02936086}
-  m_Size: {x: 0.21430087, y: 0.26127794}
+  m_Offset: {x: 0.002516669, y: -0.02491534}
+  m_Size: {x: 0.21430087, y: 0.2523868}
   m_Direction: 0
 --- !u!114 &9145982903769352726
 MonoBehaviour:
@@ -173,6 +174,10 @@ MonoBehaviour:
     m_Bits: 64
   moveSpeed: 7
   jumpForce: 7
+  knockbackForce: 5
+  knockbackCounter: 0
+  knockbackTotalTime: 0.2
+  knockbackRight: 0
   Audio: {fileID: 0}
   jumpSound: {fileID: 8300000, guid: 4e349dc959014a845b9aa317d1c2b7f0, type: 3}
   moveSound: {fileID: 8300000, guid: df7087e4d8a8bb546bc08ce68632903f, type: 3}
@@ -1183,3 +1188,69 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1001 &1452914664833386566
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 3253918218275743881}
+    m_Modifications:
+    - target: {fileID: 3577935724178491867, guid: 35b8bce522278dbeba0e69b77d2feb16, type: 3}
+      propertyPath: m_Name
+      value: Feet
+      objectReference: {fileID: 0}
+    - target: {fileID: 6007413538866340606, guid: 35b8bce522278dbeba0e69b77d2feb16, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6007413538866340606, guid: 35b8bce522278dbeba0e69b77d2feb16, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6007413538866340606, guid: 35b8bce522278dbeba0e69b77d2feb16, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6007413538866340606, guid: 35b8bce522278dbeba0e69b77d2feb16, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6007413538866340606, guid: 35b8bce522278dbeba0e69b77d2feb16, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6007413538866340606, guid: 35b8bce522278dbeba0e69b77d2feb16, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6007413538866340606, guid: 35b8bce522278dbeba0e69b77d2feb16, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6007413538866340606, guid: 35b8bce522278dbeba0e69b77d2feb16, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6007413538866340606, guid: 35b8bce522278dbeba0e69b77d2feb16, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6007413538866340606, guid: 35b8bce522278dbeba0e69b77d2feb16, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402771634019729399, guid: 35b8bce522278dbeba0e69b77d2feb16, type: 3}
+      propertyPath: playerMovement
+      value: 
+      objectReference: {fileID: 9145982903769352726}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 35b8bce522278dbeba0e69b77d2feb16, type: 3}
+--- !u!4 &5149678124750449336 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6007413538866340606, guid: 35b8bce522278dbeba0e69b77d2feb16, type: 3}
+  m_PrefabInstance: {fileID: 1452914664833386566}
+  m_PrefabAsset: {fileID: 0}

--- a/TimeMachine/Assets/Prefabs/Slime.prefab
+++ b/TimeMachine/Assets/Prefabs/Slime.prefab
@@ -1,0 +1,273 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &894103584247129265
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5994302272643421556}
+  - component: {fileID: 3093537659941653596}
+  - component: {fileID: 6570670756278684121}
+  - component: {fileID: 3827530613372816195}
+  - component: {fileID: 9165561398124953753}
+  m_Layer: 0
+  m_Name: Slime Sprite
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5994302272643421556
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 894103584247129265}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.06634501}
+  m_LocalScale: {x: 2.6882, y: 2.6882, z: 2.6882}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1318612475136772829}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &3093537659941653596
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 894103584247129265}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 4320010084133899996, guid: 52d40d1d463a123498d838dd108b712a, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.44, y: 0.3}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!70 &6570670756278684121
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 894103584247129265}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: -0.0024673596, y: -0.03287874}
+  m_Size: {x: 0.34110874, y: 0.21524325}
+  m_Direction: 1
+--- !u!114 &3827530613372816195
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 894103584247129265}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f4403652c0abfa488b0715482cd64f1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  damage: 1
+  playerHealth: {fileID: 0}
+  playerMovement: {fileID: 0}
+--- !u!95 &9165561398124953753
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 894103584247129265}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 490abd8b070b3491fa877da9ce824265, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
+--- !u!1 &3778282968974018572
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1318612475136772829}
+  - component: {fileID: 2129566038073003026}
+  - component: {fileID: 3355301434237329421}
+  - component: {fileID: 7351794670448599491}
+  m_Layer: 0
+  m_Name: Slime
+  m_TagString: Weak Point
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1318612475136772829
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3778282968974018572}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -10.48, y: -1.56, z: -0.06634501}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5994302272643421556}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!50 &2129566038073003026
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3778282968974018572}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 4
+--- !u!70 &3355301434237329421
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3778282968974018572}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0.00589062, y: 0.09661128}
+  m_Size: {x: 0.6907789, y: 0.40118334}
+  m_Direction: 1
+--- !u!114 &7351794670448599491
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3778282968974018572}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 97a5ef4674121996f85a8a7bf6839bc6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  patrolPoints:
+  - {fileID: 0}
+  - {fileID: 0}
+  moveSpeed: 2

--- a/TimeMachine/Assets/Prefabs/Slime.prefab.meta
+++ b/TimeMachine/Assets/Prefabs/Slime.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 92fbf6912ff56d03496161c3f99fe955
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TimeMachine/Assets/Scripts/EnemyScripts.meta
+++ b/TimeMachine/Assets/Scripts/EnemyScripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a55e1ee963306ffa0a4133e05de0ae38
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TimeMachine/Assets/Scripts/EnemyScripts/EnemyDamage.cs
+++ b/TimeMachine/Assets/Scripts/EnemyScripts/EnemyDamage.cs
@@ -1,0 +1,24 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+
+public class EnemyDamage : MonoBehaviour
+{
+    public int damage;
+    public Health playerHealth;
+    public SPM playerMovement;
+    
+    private void OnCollisionEnter2D(Collision2D collision){
+        if(collision.gameObject.tag == "Player"){
+            playerMovement.knockbackCounter = playerMovement.knockbackTotalTime;
+            if(collision.transform.position.x <= transform.position.x){
+                playerMovement.knockbackRight = true;
+            }
+            if(collision.transform.position.x > transform.position.x){
+                playerMovement.knockbackRight = false;
+            }
+            playerHealth.Attack();
+        }
+    }
+}

--- a/TimeMachine/Assets/Scripts/EnemyScripts/EnemyDamage.cs.meta
+++ b/TimeMachine/Assets/Scripts/EnemyScripts/EnemyDamage.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5f4403652c0abfa488b0715482cd64f1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TimeMachine/Assets/Scripts/EnemyScripts/EnemyPatrol.cs
+++ b/TimeMachine/Assets/Scripts/EnemyScripts/EnemyPatrol.cs
@@ -1,0 +1,29 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class EnemyPatrol : MonoBehaviour
+{
+    public Transform[] patrolPoints;
+    public float moveSpeed;
+    private int patrolDestination;
+
+    // Update is called once per frame
+    void Update()
+    {
+        if(patrolDestination == 0){
+            transform.position = Vector2.MoveTowards(transform.position, patrolPoints[0].position, moveSpeed * Time.deltaTime);
+            if(Vector2.Distance(transform.position, patrolPoints[0].position) < .2f){
+                transform.localScale = new Vector3(1, 1, 1);
+                patrolDestination = 1;
+            }
+        }
+        if(patrolDestination == 1){
+            transform.position = Vector2.MoveTowards(transform.position, patrolPoints[1].position, moveSpeed * Time.deltaTime);
+            if(Vector2.Distance(transform.position, patrolPoints[1].position) < .2f){
+                transform.localScale = new Vector3(-1, 1, 1);
+                patrolDestination = 0;
+            }
+        }
+    }
+}

--- a/TimeMachine/Assets/Scripts/EnemyScripts/EnemyPatrol.cs.meta
+++ b/TimeMachine/Assets/Scripts/EnemyScripts/EnemyPatrol.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 97a5ef4674121996f85a8a7bf6839bc6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TimeMachine/Assets/Scripts/EnemyScripts/EnemyStomp.cs
+++ b/TimeMachine/Assets/Scripts/EnemyScripts/EnemyStomp.cs
@@ -1,0 +1,15 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class EnemyStomp : MonoBehaviour
+{
+    public SPM playerMovement;
+
+    private void OnCollisionEnter2D(Collision2D collision){
+        if(collision.gameObject.tag == "Weak Point"){
+            Destroy(collision.gameObject);
+            playerMovement.GetRB().velocity = new Vector2(10, playerMovement.GetJumpForce() * 1.25f);
+        }
+    }
+}

--- a/TimeMachine/Assets/Scripts/EnemyScripts/EnemyStomp.cs.meta
+++ b/TimeMachine/Assets/Scripts/EnemyScripts/EnemyStomp.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 55b60cbfd40f1e0cfb2d18629cd1e4c6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TimeMachine/Assets/Scripts/SPM.cs
+++ b/TimeMachine/Assets/Scripts/SPM.cs
@@ -14,6 +14,12 @@ public class SPM : MonoBehaviour
     [SerializeField] private LayerMask jumpbleGround;
     [SerializeField] private float moveSpeed = 7f;
     [SerializeField] private float jumpForce = 10f;
+
+    public float knockbackForce;
+    public float knockbackCounter;
+    public float knockbackTotalTime;
+    public bool knockbackRight;
+
     public AudioSource Audio;
     public AudioClip jumpSound;
     public AudioClip moveSound;
@@ -37,8 +43,6 @@ public class SPM : MonoBehaviour
             dirX = Input.GetAxisRaw("Horizontal");
             rb.velocity = new Vector2(dirX*moveSpeed,rb.velocity.y);
 
-
-
             if (Input.GetButtonDown("Jump") && IsGrounded()){
                 Audio.clip = jumpSound;
                 Audio.Play();
@@ -46,6 +50,29 @@ public class SPM : MonoBehaviour
             }
 
             UpdateAnimationState();
+        }
+        if(knockbackCounter > 0){
+            sprite.color = new Color(1f, 0f, 0f, 0.85f);
+        }
+        else{
+            sprite.color = Color.white;
+        }
+    }
+
+    private void FixedUpdate() 
+    {
+        if(knockbackCounter <= 0){
+            rb.velocity = new Vector2(dirX * moveSpeed, rb.velocity.y);
+        }
+        else{
+            if(knockbackRight == true){
+                rb.velocity = new Vector2(-knockbackForce, knockbackForce/5);
+            }
+            if(knockbackRight == false){
+                rb.velocity = new Vector2(knockbackForce, knockbackForce/5);
+            }
+
+            knockbackCounter -= Time.deltaTime;
         }
     }
 
@@ -93,5 +120,13 @@ public class SPM : MonoBehaviour
         rb.velocity = Vector2.zero; // Stop any movement
         rb.bodyType = RigidbodyType2D.Static; // Completely disable physics
         coll.enabled = false; // Disable collider to prevent interactions
+    }
+
+    public Rigidbody2D GetRB(){
+        return rb;
+    }
+
+    public float GetJumpForce(){
+        return jumpForce;
     }
 }


### PR DESCRIPTION
Created Slime Prefab, Enemy Patrol Prefab
Edited Player Prefab to allow player to interact with enemies

Enemy scripts for damage to player: must be linked to Player prefab/object
Enemy patrol script: must be linked to patrol points through
Enemy stomp script: to let player kill enemies via weak point tag

Currently bugged: the damage glow overwrites the time reverse glow